### PR TITLE
Remove Luxon, add date-fns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
-  extends: ['plugin:node/recommended'],
+  extends: ['plugin:node/recommended', 'eslint:recommended'],
   plugins: ['prettier'],
+  rules: {
+    'no-unused-vars': 1
+  }
 };

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,6 +19,19 @@ blocks:
             - cache restore node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json),node-modules-$SEMAPHORE_GIT_BRANCH,node-modules-master
             - npm install
             - cache store node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json) node_modules
+  - name: Lint
+    task:
+      prologue:
+        commands:
+          - checkout
+          - nvm use
+          - node --version
+          - npm --version
+      jobs:
+        - name: Lint code
+          commands:
+            - cache restore node-modules-$SEMAPHORE_GIT_BRANCH-$(checksum package-lock.json),node-modules-$SEMAPHORE_GIT_BRANCH,node-modules-master
+            - npm run lint
   - name: Tests
     task:
       secrets:

--- a/lib/operators/convert.js
+++ b/lib/operators/convert.js
@@ -203,10 +203,10 @@ const compareBy = (attribute, a, b, config) => {
 };
 
 const compareDates = (a, b, { dateFormat }) => {
-  const dateA = datesUtil.toLuxon(a, dateFormat);
-  const dateB = datesUtil.toLuxon(b, dateFormat);
+  const dateA = datesUtil.convertToDate(a, dateFormat);
+  const dateB = datesUtil.convertToDate(b, dateFormat);
 
-  return dateB.toMillis() - dateA.toMillis();
+  return dateB.valueOf() - dateA.valueOf();
 };
 
 const compareStrings = (a, b) => {
@@ -238,7 +238,6 @@ const filterBlankLines = (content) =>
 
       return trimmed === '' ? trimmed : line;
     })
-    // .filter((line) => line.trim() !== '')
     .concat('')
     .join('\n');
 

--- a/lib/operators/generate.js
+++ b/lib/operators/generate.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 const datesUtil = require('../utils/dates.util');
 const filesUtil = require('../utils/files.util');
 

--- a/lib/utils/config.util.js
+++ b/lib/utils/config.util.js
@@ -1,5 +1,4 @@
-const { DateTime } = require('luxon');
-
+const dates = require('./dates.util');
 const files = require('./files.util');
 const { checkIsType, TYPES } = require('./types.util');
 
@@ -35,7 +34,7 @@ const checkTypes = (config) => {
 };
 
 const checkDateFormat = (dateFormat) => {
-  if (DateTime.local().toFormat(dateFormat) === dateFormat) {
+  if (dates.format(new Date(), dateFormat) === dateFormat) {
     throw Error(
       'The `dateFormat` configuration attribute must be a valid Luxon format',
     );

--- a/lib/utils/dates.util.js
+++ b/lib/utils/dates.util.js
@@ -1,24 +1,25 @@
-const { DateTime } = require('luxon');
+const dateFnsFormat = require('date-fns/format');
+const parse = require('date-fns/parse');
 
 const DEFAULT_FORMAT = 'yyyy-MM-dd HH:mm:ss';
 
-const format = (date, format) => {
+const format = (date, dateFormat) => {
   let formatted = date;
 
-  if (format !== DEFAULT_FORMAT) {
-    formatted = DateTime.fromJSDate(new Date(date)).toFormat(format);
+  if (dateFormat !== DEFAULT_FORMAT) {
+    formatted = dateFnsFormat(new Date(date), dateFormat);
   }
 
   return formatted;
 };
 
-const getCurrent = () => DateTime.local().toFormat(DEFAULT_FORMAT);
+const getCurrent = () => dateFnsFormat(new Date(), DEFAULT_FORMAT);
 
-const toLuxon = (date, format = DEFAULT_FORMAT) =>
-  DateTime.fromFormat(date, format);
+const convertToDate = (date, dateFormat = DEFAULT_FORMAT) =>
+  parse(date, dateFormat, new Date());
 
 module.exports = {
   format,
   getCurrent,
-  toLuxon,
+  convertToDate,
 };

--- a/lib/utils/files.util.js
+++ b/lib/utils/files.util.js
@@ -111,7 +111,7 @@ const ensureDirs = (dirs) => {
     currentDir = path.join(currentDir, dir);
 
     try {
-      stats = fs.statSync(currentDir);
+      fs.statSync(currentDir);
     } catch (e) {
       fs.mkdirSync(currentDir);
     }

--- a/lib/utils/templates/parse.util.js
+++ b/lib/utils/templates/parse.util.js
@@ -70,7 +70,6 @@ const parseTemplate = (filename, prefix, templateCache) => {
     } else if (nextDirective.directive === DIRECTIVES.FOR_LOOP_START) {
       const { match } = nextDirective;
 
-      //  checkStartFirst(start, end)) { // start a new for loop
       if (match.index > 0) {
         createNode(NODE_TYPES.TEXT, subTemplate.slice(0, match.index));
       }
@@ -85,8 +84,6 @@ const parseTemplate = (filename, prefix, templateCache) => {
       subTemplate = subTemplate.slice(match.index + match[0].length);
     } else if (nextDirective.directive === DIRECTIVES.FOR_LOOP_END) {
       const { match } = nextDirective;
-      //  checkEndFirst(start, end)) {
-      // close previous for loop
       createNode(NODE_TYPES.TEXT, subTemplate.slice(0, match.index));
 
       node = node.parent;

--- a/lib/utils/templates/parse.util.js
+++ b/lib/utils/templates/parse.util.js
@@ -143,9 +143,4 @@ const findNextDirective = (subTemplate) => {
   return next;
 };
 
-const checkStartFirst = (start, end) => start && end && start.index < end.index;
-
-const checkEndFirst = (start, end) =>
-  end && (!start || start.index > end.index);
-
 module.exports = parse;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-alpha.9",
       "license": "MIT",
       "dependencies": {
-        "luxon": "^1.23.0",
+        "date-fns": "^2.28.0",
         "showdown": "^1.9.1"
       },
       "bin": {
@@ -1458,6 +1458,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/date-time": {
@@ -3227,14 +3239,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.23.0.tgz",
-      "integrity": "sha512-+6a/bXsCWrrR8vfbL41iM92es12zwV2Rum/KPkT+ubOZnnU3Sqbqok/FmD1xsWlWN2Y9Hu0fU/vNgU24ns7bpA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/make-dir": {
@@ -6538,6 +6542,11 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
     "date-time": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
@@ -7918,11 +7927,6 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
-    },
-    "luxon": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.23.0.tgz",
-      "integrity": "sha512-+6a/bXsCWrrR8vfbL41iM92es12zwV2Rum/KPkT+ubOZnnU3Sqbqok/FmD1xsWlWN2Y9Hu0fU/vNgU24ns7bpA=="
     },
     "make-dir": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "coverage": "nyc ava",
     "covhtml": "nyc --reporter=lcov --reporter=text-summary ava",
     "covreport": "nyc report --reporter=text-lcov > coverage.lcov",
+    "lint": "eslint './lib' './test'",
     "test": "ava  --verbose",
     "tw": "ava --verbose --watch"
   },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "node": ">= 8.3.0"
   },
   "dependencies": {
-    "luxon": "^1.23.0",
+    "date-fns": "^2.28.0",
     "showdown": "^1.9.1"
   },
   "ava": {

--- a/test/operators/convert.test.js
+++ b/test/operators/convert.test.js
@@ -569,7 +569,6 @@ Finally out of the old house and into the new!
 });
 
 test('should enumerate output files with the same output name if no `filename` is provided', (t) => {
-  const template = templateLoader('loop-template');
   const indexTemplate = templateLoader('index-template');
 
   const sandbox = sinon.createSandbox();

--- a/test/operators/publish.test.js
+++ b/test/operators/publish.test.js
@@ -1,5 +1,4 @@
 const test = require('ava').default;
-const fs = require('fs');
 const sinon = require('sinon');
 
 const publish = require('../../lib/operators/publish');

--- a/test/utils/dates.util.test.js
+++ b/test/utils/dates.util.test.js
@@ -1,36 +1,38 @@
 const test = require('ava').default;
-const { DateTime, Settings: LuxonSettings } = require('luxon');
 const sinon = require('sinon');
 
 const dates = require('../../lib/utils/dates.util');
+let clock;
+let sandbox;
 
 test.before(() => {
-  LuxonSettings.now = () => new Date('2010-03-27 04:30:37').valueOf();
-  // const now = myDate.valueOf();
+  sandbox = sinon.createSandbox();
+  clock = sinon.useFakeTimers(new Date('2010-03-27 04:30:37').valueOf());
+});
 
-  // sinon.useFakeTimers({ now });
-  sinon.stub(DateTime, 'fromJSDate').callThrough();
-  sinon.stub(DateTime, 'local').callThrough();
+test.after(() => {
+  sandbox.restore();
+  clock.restore();
 });
 
 test('#format should take a date string and format it to the provided format', (t) => {
   t.is(dates.format('2018-08-03 08:01:00', 'M/d/yyyy'), '8/3/2018');
 });
 
-test('#getCurrent should provide current date & time', (t) => {
+test.only('#getCurrent should provide current date & time', (t) => {
   t.is(dates.getCurrent(), '2010-03-27 04:30:37');
 });
 
-test('#toLuxon should create a date time from a provided date string', (t) => {
-  const luxonDate = DateTime.local(2018, 8, 3, 8, 1, 0, 0);
-  const result = dates.toLuxon('2018-08-03 08:01:00');
+test('#convertToDate should create a date time from a provided date string', (t) => {
+  const luxonDate = new Date('2018-08-13 08:01:00');
+  const result = dates.convertToDate('2018-08-03 08:01:00');
 
-  t.is(result.toMillis(), luxonDate.toMillis());
+  t.is(result.valueOf(), luxonDate.valueOf());
 });
 
-test('#toLuxon should create a date time from a provided date string using a provided format', (t) => {
-  const luxonDate = DateTime.local(2018, 8, 3, 0, 0, 0, 0);
-  const result = dates.toLuxon('2018-08-03', 'yyyy-MM-dd');
+test('#convertToDate should create a date time from a provided date string using a provided format', (t) => {
+  const date = new Date('2018-08-13 08:01:00');
+  const result = dates.convertToDate('2018-08-03', 'yyyy-MM-dd');
 
-  t.is(result.toMillis(), luxonDate.toMillis());
+  t.is(result.valueOf(), date.valueOf());
 });


### PR DESCRIPTION
Using the date-fns library instead of Luxon. This works with the native JS `Date` object instead of a special object 

* Change `dateUtil.toLuxon` -> `dateUtil.convertToDate`
* Update tests to use a fake timer (used to use Luxon's `Settings.now`)
* Convert's compareDates relied on a Luxon method (`toMillis`), replaced it with the native `valueOf`