### PR TITLE
Update Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ understands the following attributes:
 | Attribute    | Type            | Purpose                                                                                                        | Default Value           |
 | ------------ | --------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | `built`      | `string`        | Directory where compiled post will live                                                                        | `"built"`               |
-| `dateFormat` | `string`        | The [date-fns formats](https://date-fns.org/docs/format) to use | `"yyyy-MM-dd HH:mm:ss"` |
+| `dateFormat` | `string`        | The [date-fns formats](https://date-fns.org/docs/format) to use                                                | `"yyyy-MM-dd HH:mm:ss"` |
 | `drafts`     | `string`        | Directory where draft posts live                                                                               | `"drafts"`              |
 | `pages`      | `Pages`         | The different pages to render and (optionally) the directory where they live                                   | `{ templates: [] }`     |
 | `published`  | `string`        | Directory where posts that will be compiled live                                                               | `"published"`           |
+| `updating`   | `string`        | Directory where updating posts should reside                                                                   | `"updating"`            |
 
 ### The Pages Config
 
@@ -101,6 +102,19 @@ $> npm run talc publish my-file
 # or
 $> npm run talc p my-file
 ```
+
+## Update a Published File
+
+Talc will keep a published file around while you want to update it by putting a copy in `updating`. When you're done, it will append an `update_date` to the file's metadata and overwrite the previous version in `published`. This means there is a two-step process for updating.
+
+1. Start updating a published file:
+    ```shell
+    > npm run talc update start file-to-update
+    ```
+2. When all of the updates have been made, to commit those updates, run:
+    ```shell
+    > npm run talc update finish file-to-update
+    ```
 
 Notes:
 
@@ -258,10 +272,11 @@ be recognized if placed in metadata.
 | Variable       | Purpose                                                                                                                                         | Required? | Provided? |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------- | --------- |
 | `content`      | This outputs any text content; if in a loop it'll output the value at the current index                                                         |           | :+1:      |
-| `create_date`  | Specify the date the content was created; Talc will use the `dateFormat` config attribute to format the output of this attribute                |
-| `files`        | Only available to a `"listing"` template, this provides an array of file metadata including the `filename` and any data for that file              |           | :+1:      |
-| `publish_date` | Specify the date the content moves to a published state; Talc will use the `dateFormat` config attribute to format the output of this attribute | :+1:      |
-| `title`        | The title of the content                                                                                                                        | :+1:      |
+| `create_date`  | Specify the date the content was created; Talc will use the `dateFormat` config attribute to format the output of this attribute                |           |           |
+| `files`        | Only available to a `"listing"` template, this provides an array of file metadata including the `filename` and any data for that file           |           | :+1:      |
+| `publish_date` | Specify the date the content moves to a published state; Talc will use the `dateFormat` config attribute to format the output of this attribute | :+1:      |           |
+| `title`        | The title of the content                                                                                                                        | :+1:      |           |
+| `update_date`  | The date the file was last update; only present if the file has been through the `update` process                                               |           | :+1:      |
 
 ## Loops & Listing Templates
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,9 @@ const run = (command, ...args) => {
     case 'publish':
     case 'p':
       return operators.publish(args[0], config);
+    case 'update':
+    case 'u':
+      return operators.update(args[0], args[1], config);
     /* istanbul ignore next */
     default:
       return;

--- a/lib/operators/convert.js
+++ b/lib/operators/convert.js
@@ -47,6 +47,7 @@ const partitionTemplates = (templates, directory) => {
       ...byFilename,
     };
 
+    /* istanbul ignore else */
     if (tree) {
       byType[type].push({
         ...template,

--- a/lib/operators/index.js
+++ b/lib/operators/index.js
@@ -2,4 +2,5 @@ module.exports = {
   convert: require('./convert'),
   generateMarkdown: require('./generate'),
   publish: require('./publish'),
+  update: require('./update'),
 };

--- a/lib/operators/publish.js
+++ b/lib/operators/publish.js
@@ -1,56 +1,30 @@
 const path = require('path');
 
-const datesUtil = require('../utils/dates.util');
-const filesUtil = require('../utils/files.util');
+const dates = require('../utils/dates.util');
+const files = require('../utils/files.util');
 
 const publish = (filename, { drafts, published }) => {
-  const markdownFilename = getMarkdownFilename(filename);
+  const markdownFilename = files.ensureExt(filename, 'md');
   const draftFilepath = path.join(drafts, markdownFilename);
-  const draftContents = filesUtil.readFile(draftFilepath);
-  const metadataEnd = getMetadataEnd(draftContents);
+  const draftContents = files.readFile(draftFilepath);
 
-  if (metadataEnd !== -1) {
-    filesUtil.writeFiles(published, [
+  if (draftContents) {
+    files.writeFiles(published, [
       {
-        contents: getPublishContents(draftContents, metadataEnd),
+        contents: getPublishContents(draftContents),
         filename: markdownFilename,
       },
     ]);
-    filesUtil.deleteFile(draftFilepath);
+    files.deleteFile(draftFilepath);
   }
 };
 
-const getMarkdownFilename = (filename) => {
-  const extension = path.extname(filename);
-  let markdownFilename = filename;
+const getPublishContents = (draftContents) => {
+  const publishDate = dates.getCurrent();
 
-  if (extension !== '.md') {
-    markdownFilename = `${filename}.md`;
-  }
-
-  return markdownFilename;
-};
-
-const getMetadataEnd = (contents) => {
-  const DASHES = '---';
-  const startIndex = contents.indexOf(DASHES);
-  let endIndex = -1;
-
-  if (startIndex !== -1) {
-    endIndex = contents.slice(startIndex + DASHES.length).indexOf(DASHES);
-  }
-
-  return endIndex === -1 ? -1 : endIndex + DASHES.length;
-};
-
-const getPublishContents = (draftContents, metadataEnd) => {
-  const publishDate = datesUtil.getCurrent();
-
-  return (
-    draftContents.slice(0, metadataEnd) +
-    `publish_date: ${publishDate}\n` +
-    draftContents.slice(metadataEnd)
-  );
+  return files.updateMetadata(draftContents, {
+    'publish_date': publishDate
+  });
 };
 
 module.exports = publish;

--- a/lib/operators/update.js
+++ b/lib/operators/update.js
@@ -1,0 +1,65 @@
+const path = require('path');
+
+const dates = require('../utils/dates.util');
+const files = require('../utils/files.util');
+
+const update = (action, filename, config) => {
+  if (action === 'start') {
+    startUpdating(filename, config);
+  } else if (action === 'finish') {
+    finishUpdating(filename, config);
+  } else {
+    throw new Error(
+      `"${action}" is not a known update action. Known update actions are:\n` +
+      '\t* start\n' +
+      '\t* finish\n\n'
+    );
+  }
+};
+
+const startUpdating = (filename, { published, updating }) => {
+  const trimmedFilename = (filename || '').trim();
+
+  if (!trimmedFilename) {
+    return;
+  }
+
+  const markdownFilename = files.ensureExt(trimmedFilename, 'md');
+  const publishPath = path.join(published, markdownFilename);
+  const publishedContents = files.readFile(publishPath);
+
+  if (publishedContents) {
+    files.writeFiles(updating, [
+      {
+        contents: publishedContents,
+        filename: markdownFilename,
+      }
+    ]);
+  }
+};
+
+const finishUpdating = (filename, { published, updating }) => {
+  const markdownFilename = files.ensureExt(filename, 'md');
+  const updatingPath = path.join(updating, markdownFilename);
+  const updatingContents = files.readFile(updatingPath);
+
+  if (updatingContents) {
+    files.writeFiles(published, [
+      {
+        contents: getUpdatedContents(updatingContents),
+        filename: markdownFilename,
+      }
+    ]);
+    files.deleteFile(updatingPath);
+  }
+};
+
+const getUpdatedContents = (contents) => {
+  const updateDate = dates.getCurrent();
+
+  return files.updateMetadata(contents, {
+    'update_date': updateDate,
+  });
+};
+
+module.exports = update;

--- a/lib/utils/config.util.js
+++ b/lib/utils/config.util.js
@@ -11,6 +11,7 @@ const load = () => {
     drafts: getConfigValue('drafts', userConfig),
     pages: getConfigValue('pages', userConfig, { templates: [] }),
     published: getConfigValue('published', userConfig),
+    updating: getConfigValue('updating', userConfig),
   };
 
   checkTypes(config);
@@ -82,6 +83,7 @@ const checkSortType = (sortBy) => {
   const checkItemTypes = () =>
     sortBy.findIndex((item) => typeof item !== 'string');
 
+  /* istanbul ignore else */
   if (!Array.isArray(sortBy) || !checkItemTypes()) {
     throw TypeError(
       'The `sortBy` attribute of a `templates` item in the `pages` configuration attribute must be an array of strings',

--- a/lib/utils/dates.util.js
+++ b/lib/utils/dates.util.js
@@ -15,7 +15,11 @@ const format = (date, dateFormat) => {
 
 const getCurrent = () => dateFnsFormat(new Date(), DEFAULT_FORMAT);
 
-const convertToDate = (date, dateFormat = DEFAULT_FORMAT) =>
+const convertToDate = (
+  date,
+  /* istanbul ignore next */
+  dateFormat = DEFAULT_FORMAT
+) =>
   parse(date, dateFormat, new Date());
 
 module.exports = {

--- a/lib/utils/files.util.js
+++ b/lib/utils/files.util.js
@@ -2,6 +2,26 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const deleteFile = (filepath) => {
+  if (fs.existsSync(filepath)) {
+    fs.unlinkSync(filepath);
+  }
+};
+
+const ensureExt = (filename, extension) => {
+  const dotExtension = extension[0] === '.'
+    ? extension
+    : `.${extension}`;
+  const fileExtension = path.extname(filename);
+  let withExt = filename;
+
+  if (fileExtension !== dotExtension) {
+    withExt = `${filename}${dotExtension}`;
+  }
+
+  return withExt;
+};
+
 const findRoot = (dir) => {
   const realDir = dir || process.cwd();
   const files = fs.readdirSync(realDir);
@@ -84,6 +104,7 @@ const writeFiles = (dir, files) => {
       const filepath = path.join(dir, file.filename);
       const parts = filepath.split('/');
 
+      /* istanbul ignore else */
       if (parts.length > 1) {
         ensureDirs(parts.slice(0, -1));
       }
@@ -118,17 +139,75 @@ const ensureDirs = (dirs) => {
   }
 };
 
-const deleteFile = (filepath) => {
-  if (fs.existsSync(filepath)) {
-    fs.unlinkSync(filepath);
+const updateMetadata = (original, updates) => {
+  const {
+    content,
+    metadata,
+  } = splitContent(original);
+  const withUpdates = applyMetadataUpdates(metadata, updates);
+
+  return withUpdates
+    ? `---\n${withUpdates}\n---\n${content.replace(/^\n/, '')}`
+    : content;
+};
+
+const splitContent = (original) => {
+  const matches = original.match(/^---(.+)---(.+)/s);
+  let content = original;
+  let metadata = '';
+
+  if (matches) {
+    metadata = matches[1];
+    content = matches[2];
   }
+
+  return {
+    content,
+    metadata,
+  }
+};
+
+const applyMetadataUpdates = (metadata, updates) => {
+  const lines = metadata.split('\n').filter(Boolean);
+  const remaining = { ...updates };
+  const updated = [];
+
+  const addUpdate = (attribute, value) => {
+    const trimmedValue = `${value}`.trim();
+
+    if (trimmedValue) {
+      updated.push(`${attribute}: ${trimmedValue}`);
+    }
+  };
+
+  for (const line of lines) {
+    const firstColon = line.indexOf(':');
+    const attribute = line.slice(0, firstColon).trim();
+    const value = line.slice(firstColon + 1).trim();
+    let nextValue = value;
+
+    if (remaining[attribute]) {
+      nextValue = remaining[attribute];
+      delete remaining[attribute];
+    }
+
+    addUpdate(attribute, nextValue);
+  }
+
+  for (const [attribute, value] of Object.entries(remaining)) {
+    addUpdate(attribute, value);
+  }
+
+  return updated.join('\n');
 };
 
 module.exports = {
   deleteFile,
+  ensureExt,
   findRoot,
   readFile,
   readFiles,
   requireFile,
   writeFiles,
+  updateMetadata,
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "sinon": "9.0.1"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": ">= 10.0.0"
   },
   "dependencies": {
     "date-fns": "^2.28.0",
@@ -57,7 +57,9 @@
     "files": [
       "test/**/*",
       "!test/**/fixtures",
+      "!test/test-utils.js",
       "!node_modules"
-    ]
+    ],
+    "verbose": true
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -83,3 +83,25 @@ test('should alias "publish" with "p"', (t) => {
 
   sandbox.restore();
 });
+
+test('should delegate an "update" command to the update operator', (t) => {
+  const sandbox = setup();
+  const update = sandbox.stub(operators, 'update');
+
+  run('update', 'start', 'my-file');
+
+  t.true(update.calledWith('start', 'my-file', config));
+
+  sandbox.restore();
+});
+
+test('should alias "update" with "u"', (t) => {
+  const sandbox = setup();
+  const update = sandbox.stub(operators, 'update');
+
+  run('u', 'finish', 'my-file');
+
+  t.true(update.calledWith('finish', 'my-file', config));
+
+  sandbox.restore();
+});

--- a/test/operators/publish.test.js
+++ b/test/operators/publish.test.js
@@ -49,28 +49,10 @@ We are family
   sandbox.restore();
 });
 
-test('should do nothing if there is no metadata', (t) => {
-  const config = {
-    drafts: 'drafts',
-  };
-  const draftContents = `Some contents`;
-  const sandbox = sinon.createSandbox();
-  const deleteFile = sandbox.stub(filesUtil, 'deleteFile');
-  const writeFiles = sandbox.stub(filesUtil, 'writeFiles');
-
-  sandbox.stub(filesUtil, 'readFile').returns(draftContents);
-
-  publish('draft-file', config);
-
-  t.true(deleteFile.notCalled);
-  t.true(writeFiles.notCalled);
-
-  sandbox.restore();
-});
-
 test('should be able to handle a file argument with an md extension', (t) => {
   const config = {
     drafts: 'drafts',
+    published: 'published',
   };
   const sandbox = sinon.createSandbox();
   const readFile = sandbox.stub(filesUtil, 'readFile');

--- a/test/operators/update.test.js
+++ b/test/operators/update.test.js
@@ -1,0 +1,204 @@
+const test = require('ava').default;
+const sinon = require('sinon');
+
+const filesUtil = require('../../lib/utils/files.util');
+const update = require('../../lib/operators/update');
+const { mockDate }  = require('../test-utils');
+
+test('should copy a published file to the updating directory when starting an update', (t) => {
+  const sandbox = sinon.createSandbox();
+  const readFile = sandbox.stub(filesUtil, 'readFile');
+  const writeFiles = sandbox.stub(filesUtil, 'writeFiles');
+  const config = {
+    drafts: 'drafts',
+    published: 'published',
+    updating: 'updating',
+  };
+  const publishedContents = `---
+  title: This is My Post
+  create_date: 2004-01-21 23:30:00
+  publish_date: 2010-03-27 16:30:00
+  ---
+
+  We are family
+      `;
+
+  readFile.returns(publishedContents);
+
+  update('start', 'pubbed', config);
+
+  t.true(readFile.calledOnceWith('published/pubbed.md'));
+  t.true(writeFiles.calledOnceWith('updating', [
+    {
+      contents: publishedContents,
+      filename: 'pubbed.md'
+    }
+  ]));
+
+  sandbox.restore();
+});
+
+test('should not start updating if the provided file is not published', (t) => {
+  const sandbox = sinon.createSandbox();
+  const config = {
+    published: 'published',
+  };
+  const readFile = sandbox.stub(filesUtil, 'readFile');
+  const writeFiles = sandbox.stub(filesUtil, 'writeFiles');
+
+  readFile.returns();
+
+  update('start', 'doesnt-exist', config);
+
+  t.true(readFile.calledOnceWith('published/doesnt-exist.md'));
+  t.false(writeFiles.called);
+
+  sandbox.restore();
+});
+
+test('should not start updating if no filename is provided', (t) => {
+  const sandbox = sinon.createSandbox();
+  const config = {
+    published: 'published',
+  };
+  const readFile = sandbox.stub(filesUtil, 'readFile');
+
+  update('start', '       ', config);
+  update('start', undefined, config);
+  update('start', null, config);
+  update('start', false, config);
+
+  t.false(readFile.called);
+
+  sandbox.restore();
+});
+
+test('should copy a file from updating to published with an updated date when finishing an update and remove the file from updating', (t) => {
+  const sandbox = sinon.createSandbox();
+  const deleteFile = sandbox.stub(filesUtil, 'deleteFile');
+  const readFile = sandbox.stub(filesUtil, 'readFile');
+  const writeFiles = sandbox.stub(filesUtil, 'writeFiles');
+  const clock = mockDate('2022-10-17 00:00:00');
+  const config = {
+    drafts: 'drafts',
+    published: 'published',
+    updating: 'updating',
+  };
+  const updatingContents = `---
+title: This is My Post
+create_date: 2004-01-21 23:30:00
+publish_date: 2010-03-27 16:30:00
+---
+
+We are family
+
+UPDATE: another bay-beeeee?
+    `;
+  const publishedContents = `---
+title: This is My Post
+create_date: 2004-01-21 23:30:00
+publish_date: 2010-03-27 16:30:00
+update_date: 2022-10-17 00:00:00
+---
+
+We are family
+
+UPDATE: another bay-beeeee?
+    `;
+
+  readFile.returns(updatingContents);
+
+  update('finish', 'up-date', config);
+
+  t.true(readFile.calledOnceWith('updating/up-date.md'));
+  t.true(writeFiles.calledOnceWith('published', [
+    {
+      contents: publishedContents,
+      filename: 'up-date.md'
+    }
+  ]));
+  t.true(deleteFile.calledOnceWith('updating/up-date.md'));
+
+  clock.restore();
+  sandbox.restore();
+});
+
+test('should overwrite a previous update_date value if present', (t) => {
+  const sandbox = sinon.createSandbox();
+  const deleteFile = sandbox.stub(filesUtil, 'deleteFile');
+  const readFile = sandbox.stub(filesUtil, 'readFile');
+  const writeFiles = sandbox.stub(filesUtil, 'writeFiles');
+  const clock = mockDate('2022-10-17 00:00:00');
+  const config = {
+    drafts: 'drafts',
+    published: 'published',
+    updating: 'updating',
+  };
+  const updatingContents = `---
+title: This is My Post
+create_date: 2004-01-21 23:30:00
+publish_date: 2010-03-27 16:30:00
+update_date: 2017-11-13 00:00:00
+---
+
+We are family
+
+UPDATE: another bay-beeeee?
+    `;
+  const publishedContents = `---
+title: This is My Post
+create_date: 2004-01-21 23:30:00
+publish_date: 2010-03-27 16:30:00
+update_date: 2022-10-17 00:00:00
+---
+
+We are family
+
+UPDATE: another bay-beeeee?
+    `;
+
+  readFile.returns(updatingContents);
+
+  update('finish', 'up-date', config);
+
+  t.true(readFile.calledOnceWith('updating/up-date.md'));
+  t.true(writeFiles.calledOnceWith('published', [
+    {
+      contents: publishedContents,
+      filename: 'up-date.md'
+    }
+  ]));
+  t.true(deleteFile.calledOnceWith('updating/up-date.md'));
+
+  clock.restore();
+  sandbox.restore();
+});
+
+test('should do nothing if the update file has no contents', (t) => {
+  const sandbox = sinon.createSandbox();
+  const readFile = sandbox.stub(filesUtil, 'readFile');
+  const writeFiles = sandbox.stub(filesUtil, 'writeFiles');
+  const config = { updating: 'updating' };
+
+  readFile.returns();
+
+  update('finish', 'not-there', config);
+
+  t.true(readFile.called);
+  t.false(writeFiles.called);
+
+  sandbox.restore();
+});
+
+test('should throw an error for an unknown action', (t) => {
+  const error = t.throws(() => (
+    update('some-bad-action')
+  ), { instanceOf: Error })
+
+  t.is(
+    error.message,
+    '"some-bad-action" is not a known update action. Known update actions are:\n' +
+    '\t* start\n' +
+    '\t* finish\n\n'
+  )
+})

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,0 +1,10 @@
+const sinon = require('sinon');
+
+/* istanbul ignore file */
+const mockDate = (date) => (
+  sinon.useFakeTimers(new Date(date).valueOf())
+);
+
+module.exports = {
+  mockDate,
+};

--- a/test/utils/config.util.test.js
+++ b/test/utils/config.util.test.js
@@ -35,6 +35,7 @@ test('should look for a config file next to the nearest package.json', (t) => {
       ],
     },
     published: 'input',
+    updating: 'rework'
   };
 
   t.deepEqual(load(), userConfig);
@@ -50,6 +51,7 @@ test('should use a default config if one is not present', (t) => {
       templates: [],
     },
     published: 'published',
+    updating: 'updating',
   });
 });
 
@@ -67,6 +69,7 @@ test('should use a partial config', (t) => {
       templates: [],
     },
     published: 'pizza',
+    updating: 'updating',
   });
 });
 

--- a/test/utils/dates.util.test.js
+++ b/test/utils/dates.util.test.js
@@ -1,17 +1,15 @@
 const test = require('ava').default;
-const sinon = require('sinon');
 
 const dates = require('../../lib/utils/dates.util');
+const { mockDate } = require('../test-utils');
+
 let clock;
-let sandbox;
 
 test.before(() => {
-  sandbox = sinon.createSandbox();
-  clock = sinon.useFakeTimers(new Date('2010-03-27 04:30:37').valueOf());
+  clock = mockDate('2010-03-27 04:30:37');
 });
 
 test.after(() => {
-  sandbox.restore();
   clock.restore();
 });
 
@@ -32,7 +30,7 @@ test('#convertToDate should create a date time from a provided date string', (t)
 
 test('#convertToDate should create a date time from a provided date string using a provided format', (t) => {
   const date = new Date('2018-08-13 08:01:00');
-  const result = dates.convertToDate('2018-08-03', 'yyyy-MM-dd');
+  const result = dates.convertToDate('03 Aug 18', 'dd MMM yy');
 
   t.is(result.valueOf(), date.valueOf());
 });


### PR DESCRIPTION
This PR adds an `update` operator which allows users to put a post into an updating state so they can edit it without taking the published post out of published or editing it in-place.

To start an update:

```shell
> npm run talc update start <filename>
```

This will dump it into the updating directory (default is `updating`). When the update is finished and can be re-published:

```shell
> npm run talc update finish <filename>
```

This `finish` action will append an `update_date` timestamp to the metadata of the post, overwrite the previous file in the published directory, and delete the one in `updating`.