### PR TITLE
Refactor template conversion

### DIFF
--- a/lib/utils/templates/parse.util.js
+++ b/lib/utils/templates/parse.util.js
@@ -12,7 +12,12 @@ const parse = (prefix, file, templateCache = {}) => {
 
   /* istanbul ignore else */
   if (!tree) {
-    ({ tree, cached } = parseTemplate(filename, prefix, templateCache));
+    const parser = new Parser(filename, prefix, templateCache);
+
+    parser.parse();
+
+    cached = parser.getCache();
+    tree = parser.getTree();
   }
 
   return {
@@ -21,149 +26,185 @@ const parse = (prefix, file, templateCache = {}) => {
   };
 };
 
-const parseTemplate = (filename, prefix, templateCache) => {
-  const template = filesUtil.readFile(filename);
-  let cached = { ...templateCache };
-  let subTemplate = template;
-  let tree = null;
-  let node = null;
-  let parent = null;
-  let previous = null;
+class Parser {
+  constructor(filename, prefix, cache) {
+    this._cache = { ...cache };
+    this._filename = filename;
+    this._node = null;
+    this._parent = null;
+    this._prefix = prefix;
+    this._previous = null;
+    this._template = filesUtil.readFile(filename);
+    this._tree = null;
+  }
 
-  const createStartNode = (type, match, attribute) => {
-    completePreviousNode(match.index);
+  static checkIsChildless(node) {
+    return node
+      && node.content
+      && !node.content.child;
+  }
 
-    createNode(type, {
-      child: null,
-      [attribute]: match[1],
-    });
-    parent = node;
-    previous = null;
+  static findNextDirective(template) {
+    let next;
 
-    subTemplate = subTemplate.slice(match.index + match[0].length);
-  };
+    for (const directive of Object.values(DIRECTIVES)) {
+      const match = template.match(DIRECTIVE_REGEX[directive]);
 
-  const createEndNode = (match) => {
-    createNode(NODE_TYPES.TEXT, subTemplate.slice(0, match.index));
+      // if we haven't found a next or the current match
+      // comes before the current next
+      if (match && (!next || match.index < next.match.index)) {
+        next = {
+          directive,
+          match,
+        };
+      }
+    }
 
-    node = node.parent;
-    previous = node;
-    ({ parent } = node);
+    return next;
+  }
 
-    subTemplate = subTemplate.slice(match.index + match[0].length);
-  };
+  getCache() {
+    return this._cache;
+  }
 
-  const completePreviousNode = (matchIndex) => {
+  getTree() {
+    return this._tree;
+  }
+
+  parse(template = this._template) {
+    const directive = Parser.findNextDirective(template);
+
+    if (!directive) {
+      this._insertTextNode(template);
+    } else {
+      this._completePreviousNode(directive, template);
+      this._handleDirective(directive, template);
+      this._advanceTemplate(directive.match, template);
+    }
+
+    this._cache[this._filename] = this._tree;
+  }
+
+  _completePreviousNode({ match, directive }, template) {
+    const needComplete = [
+      DIRECTIVES.FOR_LOOP_START,
+      DIRECTIVES.IF_BLOCK_START,
+      DIRECTIVES.IMPORT_PARTIAL,
+    ];
+
     /* istanbul ignore else */
-    if (matchIndex > 0) {
-      createNode(NODE_TYPES.TEXT, subTemplate.slice(0, matchIndex));
+    if (needComplete.includes(directive) && match.index > 0) {
+      this._insertTextNode(template.slice(0, match.index));
     }
   }
 
-  const createNode = (type, content) => {
-    node = {
+  _handleDirective(directive, template) {
+    switch (directive.directive) {
+      case DIRECTIVES.FOR_LOOP_START:
+        return this._insertForLoopStart(directive);
+      case DIRECTIVES.IF_BLOCK_START:
+        return this._insertIfBlockStart(directive);
+      case DIRECTIVES.FOR_LOOP_END:
+      case DIRECTIVES.IF_BLOCK_END:
+        return this._insertEndNode(directive, template);
+      case DIRECTIVES.IMPORT_PARTIAL:
+        return this._insertPartial(directive, template)
+    }
+  }
+
+  _insertForLoopStart(directive) {
+    this._insertStartNode(
+      NODE_TYPES.FOR_LOOP,
+      directive.match,
+      'variable',
+    );
+  }
+
+  _insertIfBlockStart(directive, template) {
+    this._insertStartNode(
+      NODE_TYPES.IF_BLOCK,
+      directive.match,
+      'condition',
+      template,
+    );
+  }
+
+  _insertStartNode(type, match, variable) {
+    const content = {
+      child: null,
+      [variable]: match[1],
+    };
+
+    this._insertNode(type, content);
+    this._parent = this._node;
+    this._previous = null;
+  }
+
+  _insertEndNode({ match }, template) {
+    this._insertTextNode(template.slice(0, match.index));
+
+    this._node = this._node.parent;
+    this._previous = this._node;
+    this._parent = this._node.parent;
+  }
+
+  _insertTextNode(text) {
+    this._insertNode(NODE_TYPES.TEXT, text);
+  }
+
+  _insertPartial({ match }) {
+    const file = match[1];
+    let partialTree = this._cache[file];
+
+    /* istanbul ignore else */
+    if (!partialTree) {
+      // create new parser and parse the partial file
+      const partialParser = new Parser(file, this._prefix, this._cache);
+
+      partialParser.parse();
+      this._cache = {
+        ...partialParser.getCache(),
+        ...this._cache,
+      };
+      partialTree = partialParser.getTree();
+    }
+
+    /* istanbul ignore else */
+    if (partialTree) {
+      this._insertNode(NODE_TYPES.PARTIAL, partialTree);
+    }
+  }
+
+  _insertNode(type, content) {
+    const node = {
       content,
-      parent,
       next: null,
-      previous,
+      parent: this._parent,
+      previous: this._previous,
       type,
     };
 
-    // set the new node to previous nodes
-    // next sibling
-    if (previous) {
-      previous.next = node;
+    if (this._previous) {
+      this._previous.next = node;
     }
 
-    // if the node is a child (its in a block) and
-    // its parent has no first child set, set this
-    // node as the parent's first child
-    if (node.parent && node.parent.content && !node.parent.content.child) {
+    if (Parser.checkIsChildless(node.parent)) {
       node.parent.content.child = node;
     }
 
-    previous = node;
+    this._node = node;
+    this._previous = node;
 
-    // if a tree hasn't been established (the root node)
-    // set this node as the root
-    if (!tree) {
-      tree = node;
-    }
-  };
-
-  while (subTemplate) {
-    const nextDirective = findNextDirective(subTemplate);
-
-    /* istanbul ignore else */
-    if (!nextDirective) {
-      // normal text node just add the rest of the subTemplate
-      createNode(NODE_TYPES.TEXT, subTemplate);
-      subTemplate = null;
-    } else if (nextDirective.directive === DIRECTIVES.FOR_LOOP_START) {
-      createStartNode(
-        NODE_TYPES.FOR_LOOP,
-        nextDirective.match,
-        'variable',
-      );
-    } else if (nextDirective.directive === DIRECTIVES.FOR_LOOP_END
-        || nextDirective.directive === DIRECTIVES.IF_BLOCK_END) {
-      createEndNode(nextDirective.match);
-    } else if (nextDirective.directive === DIRECTIVES.IF_BLOCK_START) {
-      createStartNode(
-        NODE_TYPES.IF_BLOCK,
-        nextDirective.match,
-        'condition',
-      );
-    } else if (nextDirective.directive === DIRECTIVES.IMPORT_PARTIAL) {
-      const { match } = nextDirective;
-
-      completePreviousNode(match.index);
-
-      const partialFile = match[1];
-      let partialTree = cached[partialFile];
-
-      /* istanbul ignore else */
-      if (!partialTree) {
-        const parsedPartial = parse(prefix, partialFile, cached);
-
-        cached = {
-          ...parsedPartial.cached,
-          ...cached,
-        };
-        partialTree = parsedPartial.tree;
-      }
-
-      /* istanbul ignore else */
-      if (partialTree) {
-        createNode(NODE_TYPES.PARTIAL, partialTree);
-      }
-
-      subTemplate = subTemplate.slice(match.index + match[0].length);
+    if (!this._tree) {
+      this._tree = node;
     }
   }
 
-  cached[template] = tree;
+  _advanceTemplate(match, template) {
+    const nextTemplate = template.slice(match.index + match[0].length);
 
-  return { tree, cached };
-};
-
-const findNextDirective = (subTemplate) => {
-  let next;
-
-  for (const directive of Object.values(DIRECTIVES)) {
-    const match = subTemplate.match(DIRECTIVE_REGEX[directive]);
-
-    // if we haven't found a next or the current match
-    // comes before the current next
-    if (match && (!next || match.index < next.match.index)) {
-      next = {
-        directive,
-        match,
-      };
-    }
+    this.parse(nextTemplate);
   }
-
-  return next;
-};
+}
 
 module.exports = parse;

--- a/lib/utils/templates/reconstruct.util.js
+++ b/lib/utils/templates/reconstruct.util.js
@@ -1,6 +1,9 @@
 const { NODE_TYPES } = require('../../constants/ast');
 const { checkIsType, TYPES } = require('../types.util');
 
+const reconstructForLoop = require('./reconstructors/for.reconstruct');
+const reconstructIfBlock = require('./reconstructors/if.reconstruct');
+
 const reconstruct = (tree, metadata, contents) => {
   let content = '';
 
@@ -10,25 +13,9 @@ const reconstruct = (tree, metadata, contents) => {
   } else if (tree.type === NODE_TYPES.PARTIAL) {
     content += reconstruct(tree.content, metadata);
   } else if (tree.type === NODE_TYPES.FOR_LOOP) {
-    const { variable } = tree.content;
-    const metadataValue =
-      metadata[variable] ||
-      (checkIsType(contents, TYPES.OBJECT) && contents[variable]);
-
-    if (Array.isArray(metadataValue)) {
-      for (const value of metadataValue) {
-        content += reconstruct(tree.content.child, metadata, value);
-      }
-    }
+    content += reconstructForLoop(tree, metadata, contents, reconstruct);
   } else if (tree.type === NODE_TYPES.IF_BLOCK) {
-    const { child, condition } = tree.content;
-    const match = condition.match(/(.+)(===|!==|>=|>|<=|<)(.+)/s);
-
-    if ((!match || match.length === 1) && metadata[condition]) {
-      content += reconstruct(child, metadata);
-    } else if (match && checkConditionTrue(match, metadata)) {
-      content += reconstruct(child, metadata);
-    }
+    content += reconstructIfBlock(tree, metadata, reconstruct);
   }
 
   content = replaceVariables(content, metadata, contents);
@@ -39,66 +26,6 @@ const reconstruct = (tree, metadata, contents) => {
 
   return content;
 };
-
-const checkConditionTrue = (match, metadata) => {
-  const lhs = match[1].trim();
-  const op = match[2].trim();
-  const rhs = match[3].trim();
-  let isTrue = false;
-  let eqValue;
-  let value;
-
-  /* istanbul ignore else */
-  if (lhs in metadata) {
-    value = metadata[lhs];
-    eqValue = rhs;
-  } else if (rhs in metadata) {
-    value = metadata[rhs];
-    eqValue = lhs;
-  }
-
-  /* istanbul ignore else */
-  if (value && eqValue) {
-    isTrue = evaluateCondition(op, value, eqValue);
-  }
-
-  return isTrue;
-};
-
-const evaluateCondition = (op, value, eqValue) => {
-  const evalValue = convertValue(value);
-  const evalEqValue = convertValue(eqValue);
-
-  switch (op) {
-    case '===':
-      return evalValue === evalEqValue;
-    case '!==':
-      return evalValue !== evalEqValue;
-    case '<':
-      return evalValue < evalEqValue;
-    case '>=':
-      return evalValue >= evalEqValue;
-    case '>':
-      return evalValue > evalEqValue;
-    case '<=':
-      return evalValue <= evalEqValue;
-    /* istanbul ignore next */
-    default:
-      return false;
-  }
-};
-
-const convertValue = (value) => {
-  let converted = value;
-
-  try {
-    converted = eval(value);
-  } catch (e) {
-    converted = value;
-  }
-
-  return converted;
-}
 
 const replaceVariables = (content, metadata, contents) => {
   const variableRegex = /<!--\s*talc:([a-zA-Z0-9_]+)\s*-->/;

--- a/lib/utils/templates/reconstructors/for.reconstruct.js
+++ b/lib/utils/templates/reconstructors/for.reconstruct.js
@@ -1,0 +1,18 @@
+const { checkIsType, TYPES } = require("../../types.util");
+
+const reconstructForLoop = (tree, metadata, contents, reconstruct) => {
+  const { variable } = tree.content;
+  const metadataValue = metadata[variable] ||
+      (checkIsType(contents, TYPES.OBJECT) && contents[variable]);
+  let content = '';
+
+  if (Array.isArray(metadataValue)) {
+    for (const value of metadataValue) {
+      content += reconstruct(tree.content.child, metadata, value);
+    }
+  }
+
+  return content;
+};
+
+module.exports = reconstructForLoop;

--- a/lib/utils/templates/reconstructors/if.reconstruct.js
+++ b/lib/utils/templates/reconstructors/if.reconstruct.js
@@ -1,0 +1,75 @@
+const reconstructIfBlock = (tree, metadata, reconstruct) => {
+  const { child, condition } = tree.content;
+  const match = condition.match(/(.+)(===|!==|>=|>|<=|<)(.+)/s);
+  let content = '';
+
+  if ((!match || match.length === 1) && metadata[condition]) {
+    content += reconstruct(child, metadata);
+  } else if (match && checkConditionTrue(match, metadata)) {
+    content += reconstruct(child, metadata);
+  }
+
+  return content;
+}
+
+const checkConditionTrue = (match, metadata) => {
+  const lhs = match[1].trim();
+  const op = match[2].trim();
+  const rhs = match[3].trim();
+  let isTrue = false;
+  let eqValue;
+  let value;
+
+  /* istanbul ignore else */
+  if (lhs in metadata) {
+    value = metadata[lhs];
+    eqValue = rhs;
+  } else if (rhs in metadata) {
+    value = metadata[rhs];
+    eqValue = lhs;
+  }
+
+  /* istanbul ignore else */
+  if (value && eqValue) {
+    isTrue = evaluateCondition(op, value, eqValue);
+  }
+
+  return isTrue;
+};
+
+const evaluateCondition = (op, value, eqValue) => {
+  const evalValue = convertValue(value);
+  const evalEqValue = convertValue(eqValue);
+
+  switch (op) {
+    case '===':
+      return evalValue === evalEqValue;
+    case '!==':
+      return evalValue !== evalEqValue;
+    case '<':
+      return evalValue < evalEqValue;
+    case '>=':
+      return evalValue >= evalEqValue;
+    case '>':
+      return evalValue > evalEqValue;
+    case '<=':
+      return evalValue <= evalEqValue;
+    /* istanbul ignore next */
+    default:
+      return false;
+  }
+};
+
+const convertValue = (value) => {
+  let converted = value;
+
+  try {
+    converted = eval(value);
+  } catch (e) {
+    converted = value;
+  }
+
+  return converted;
+};
+
+module.exports = reconstructIfBlock;


### PR DESCRIPTION
This change does two things:

1. The template parsing code now uses a class-based approach. The code is a bit cleaner and instead of using a while loop, now uses recursion which I find a bit easier to follow.
2. The reconstruction of the template is also refactored so that if blocks and for loops are in their own files