### PR TITLE
Allow Assets in Templates and Posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ understands the following attributes:
 
 | Attribute    | Type            | Purpose                                                                                                        | Default Value           |
 | ------------ | --------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `built`      | `string`        | Directory where compiled post will live                                                                        | `"built"`               |
-| `dateFormat` | `string`        | The [date-fns formats](https://date-fns.org/docs/format) to use                                                | `"yyyy-MM-dd HH:mm:ss"` |
+| `assets`     | `string`        | Directory where asset files can be found                                                                       | `""`                    |
+| `built`      | `string`        | Directory where compiled posts will live                                                                       | `"built"`               |
+| `dateFormat` | `string`        | The [`date-fns` formats](https://date-fns.org/docs/format) to use                                                | `"yyyy-MM-dd HH:mm:ss"` |
 | `drafts`     | `string`        | Directory where draft posts live                                                                               | `"drafts"`              |
 | `pages`      | `Pages`         | The different pages to render and (optionally) the directory where they live                                   | `{ templates: [] }`     |
 | `published`  | `string`        | Directory where posts that will be compiled live                                                               | `"published"`           |
@@ -375,3 +376,56 @@ While the following are _not_ valid:
 published_date < crated_date
 'alpha' !== 'beta'
 ```
+
+## Managing Assets
+
+Perhaps you want to include images, videos, or other media assets into your templates and posts. Talc can track these assets and copy them over for you using the `talc:asset:<filename>` directive. How this directive is used differs slightly between templates and posts.
+
+File type|Usage
+---|---
+Template|`<!-- talc:asset:my/file.jpg -->`
+Post|`%talc:asset:my/file.jpg -->`
+
+So a template may look like this:
+
+```html
+<html>
+  <head>
+    <title>My Page with Assets</title>
+
+    <link rel="stylesheet" href="<!-- talc:asset:css/main.css -->">
+  </head>
+
+  <body>
+    <header>
+      <img src="<!-- talc:asset:imgs/banner.png -->" alt="Site banner">
+    </head>
+
+    <main>
+      <!-- talc:content -->
+    </main>
+  </body>
+</html>
+```
+
+And then a post may look like:
+
+```
+---
+title: Post Title
+---
+
+![Img alt text](%talc:asset:imgs/posts/99-balloons.jpg)
+
+There are 99 balloons above!
+```
+
+Talc will identify all of these specified assets and attempt to copy them to your `config.built` directory, creating directories as needed. So when the above files are processed, in the `config.built` directory, Talc will also attempt to create the following directories:
+
+* `css`
+* `imgs`
+* `imgs/posts`
+
+> **NOTE:** if any of the specified assets cannot be found, Talc will throw an `ReferenceError` and abort
+
+If `config.assets` is specified, Talc will look for the the asset files in that directory. Otherwise, it will look for them in the root directory.

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ So a template may look like this:
 
 And then a post may look like:
 
-```
+```markdown
 ---
 title: Post Title
 ---

--- a/lib/constants/ast.js
+++ b/lib/constants/ast.js
@@ -1,4 +1,5 @@
 const NODE_TYPES = {
+  ASSET: 'asset',
   FOR_LOOP: 'for',
   IF_BLOCK: 'if',
   PARTIAL: 'partial',
@@ -6,6 +7,7 @@ const NODE_TYPES = {
 };
 
 const DIRECTIVES = {
+  ASSET: 'ASSET',
   FOR_LOOP_END: 'FOR_LOOP_END',
   FOR_LOOP_START: 'FOR_LOOP_START',
   IF_BLOCK_END: 'IF_BLOCK_END',
@@ -14,6 +16,7 @@ const DIRECTIVES = {
 };
 
 const DIRECTIVE_REGEX = {
+  [DIRECTIVES.ASSET]: /<!--\s*talc:asset:([^\s-]+)\s*-->/,
   [DIRECTIVES.FOR_LOOP_END]: /<!--\s*talc:endfor\s*-->/,
   [DIRECTIVES.FOR_LOOP_START]: /<!--\s*talc:for:([^\s-]+)\s*-->/,
   [DIRECTIVES.IF_BLOCK_END]: /<!--\s*talc:endif\s*-->/,

--- a/lib/operators/convert.js
+++ b/lib/operators/convert.js
@@ -22,11 +22,16 @@ const convert = (config) => {
   const uniqueFiles = getUniqueNames(postFiles.concat(listingFiles));
   const managed = manageAssets(uniqueFiles);
   let uniqueAssets = Array.from(new Set([...assets, ...managed.assets]));
+  let renameAsset;
 
-  // TODO: allow assets to be pulled from a configurable location
+  if (config.assets) {
+    renameAsset = (asset) =>
+      asset.replace(new RegExp(`^${path.join(config.assets, path.sep)}`), '');
+    uniqueAssets = uniqueAssets.map((asset) => path.join(config.assets, asset));
+  }
 
   filesUtil.writeFiles(config.built, managed.files);
-  filesUtil.copyFiles(config.built, uniqueAssets);
+  filesUtil.copyFiles(config.built, uniqueAssets, renameAsset);
 };
 
 const partitionTemplates = (templates, directory) => {

--- a/lib/operators/convert.js
+++ b/lib/operators/convert.js
@@ -6,7 +6,7 @@ const filesUtil = require('../utils/files.util');
 const templatesUtil = require('../utils/templates');
 
 const convert = (config) => {
-  const { byType, byFilename } = partitionTemplates(
+  const { assets, byType, byFilename } = partitionTemplates(
     config.pages.templates,
     config.pages.directory,
   );
@@ -19,11 +19,14 @@ const convert = (config) => {
     config,
     byFilename,
   );
+  const uniqueFiles = getUniqueNames(postFiles.concat(listingFiles));
+  const managed = manageAssets(uniqueFiles);
+  let uniqueAssets = Array.from(new Set([...assets, ...managed.assets]));
 
-  filesUtil.writeFiles(
-    config.built,
-    getUniqueNames(postFiles.concat(listingFiles)),
-  );
+  // TODO: allow assets to be pulled from a configurable location
+
+  filesUtil.writeFiles(config.built, managed.files);
+  filesUtil.copyFiles(config.built, uniqueAssets);
 };
 
 const partitionTemplates = (templates, directory) => {
@@ -31,11 +34,12 @@ const partitionTemplates = (templates, directory) => {
     listing: [],
     post: [],
   };
+  const allAssets = [];
   const prefix = directory ? `${directory}${path.sep}` : '';
   let byFilename = {};
 
   for (const template of templates) {
-    const { tree, cached } = templatesUtil.parse(
+    const { assets, cached, tree } = templatesUtil.parse(
       prefix,
       template.template,
       byFilename,
@@ -46,6 +50,7 @@ const partitionTemplates = (templates, directory) => {
       ...cached,
       ...byFilename,
     };
+    allAssets.push(...assets);
 
     /* istanbul ignore else */
     if (tree) {
@@ -62,7 +67,7 @@ const partitionTemplates = (templates, directory) => {
     byType.post.push(null);
   }
 
-  return { byFilename, byType };
+  return { assets: allAssets, byFilename, byType };
 };
 
 const transformPosts = (templates, files, config) => {
@@ -275,6 +280,30 @@ const getUniqueNames = (files) => {
   }
 
   return uniquelyNamedFiles;
+};
+
+const manageAssets = (files) => {
+  const assetRegex = /%talc:asset:([^%]*)%/g;
+  const assets = [];
+  const managedFiles = [];
+
+  for (const file of files) {
+    const managedContents = file.contents.replace(
+      assetRegex,
+      (_match, file) => {
+        assets.push(file);
+
+        return file;
+      },
+    );
+
+    managedFiles.push({
+      ...file,
+      contents: managedContents,
+    });
+  }
+
+  return { assets, files: managedFiles };
 };
 
 module.exports = convert;

--- a/lib/utils/config.util.js
+++ b/lib/utils/config.util.js
@@ -6,6 +6,7 @@ const load = () => {
   const rootDir = files.findRoot();
   const userConfig = files.requireFile(rootDir, 'talc.config.js');
   const config = {
+    assets: getConfigValue('assets', userConfig, ''),
     built: getConfigValue('built', userConfig),
     dateFormat: getConfigValue('dateFormat', userConfig, 'yyyy-MM-dd HH:mm:ss'),
     drafts: getConfigValue('drafts', userConfig),
@@ -30,15 +31,28 @@ const getConfigValue = (dir, userConfig, defaultValue) => {
 };
 
 const checkTypes = (config) => {
+  checkAssetsFormat(config.assets);
   checkDateFormat(config.dateFormat);
   checkPagesStructure(config.pages);
+};
+
+const checkAssetsFormat = (assets) => {
+  if (!checkIsType(assets, TYPES.STRING)) {
+    throw TypeError('The `assets` configuration attribute must be a string');
+  }
+
+  if (assets && !files.checkIsDir(assets)) {
+    throw ReferenceError(
+      'The `assets` configuration attribute must be to a valid directory',
+    );
+  }
 };
 
 const checkDateFormat = (dateFormat) => {
   if (dates.format(new Date(), dateFormat) === dateFormat) {
     throw Error(
       'The `dateFormat` configuration attribute must be a valid date format.\n' +
-      'Please see https://date-fns.org/docs/format for more information'
+        'Please see https://date-fns.org/docs/format for more information',
     );
   }
 };

--- a/lib/utils/files.util.js
+++ b/lib/utils/files.util.js
@@ -119,13 +119,18 @@ const writeFiles = (dir, files) => {
   }
 };
 
-const copyFiles = (destDir, files) => {
-  for (const file of files) {
-    const dest = path.join(destDir, file);
+const copyFiles = (destDir, files, transformFilename) => {
+  let transform = (filename) => filename;
 
+  if (typeof transformFilename === 'function') {
+    transform = transformFilename;
+  }
+
+  for (const file of files) {
     if (!fs.existsSync(file)) {
       throw new ReferenceError(`Could not copy over the asset named "${file}"`);
     }
+    const dest = path.join(destDir, transform(file));
 
     ensureDirpath(dest);
     fs.copyFileSync(file, dest);

--- a/lib/utils/files.util.js
+++ b/lib/utils/files.util.js
@@ -158,6 +158,20 @@ const ensureDir = (dir) => {
   }
 };
 
+const checkIsDir = (dir) => {
+  let isDir = true;
+
+  try {
+    const stats = fs.statSync(dir);
+
+    isDir = stats.isDirectory();
+  } catch (e) {
+    isDir = false;
+  }
+
+  return isDir;
+};
+
 const updateMetadata = (original, updates) => {
   const { content, metadata } = splitContent(original);
   const withUpdates = applyMetadataUpdates(metadata, updates);
@@ -218,6 +232,7 @@ const applyMetadataUpdates = (metadata, updates) => {
 };
 
 module.exports = {
+  checkIsDir,
   copyFiles,
   deleteFile,
   ensureExt,

--- a/lib/utils/files.util.js
+++ b/lib/utils/files.util.js
@@ -9,9 +9,7 @@ const deleteFile = (filepath) => {
 };
 
 const ensureExt = (filename, extension) => {
-  const dotExtension = extension[0] === '.'
-    ? extension
-    : `.${extension}`;
+  const dotExtension = extension[0] === '.' ? extension : `.${extension}`;
   const fileExtension = path.extname(filename);
   let withExt = filename;
 
@@ -102,12 +100,8 @@ const writeFiles = (dir, files) => {
 
     if (contents) {
       const filepath = path.join(dir, file.filename);
-      const parts = filepath.split('/');
 
-      /* istanbul ignore else */
-      if (parts.length > 1) {
-        ensureDirs(parts.slice(0, -1));
-      }
+      ensureDirpath(filepath);
 
       haveContents.push({
         contents,
@@ -125,25 +119,47 @@ const writeFiles = (dir, files) => {
   }
 };
 
+const copyFiles = (destDir, files) => {
+  for (const file of files) {
+    const dest = path.join(destDir, file);
+
+    if (!fs.existsSync(file)) {
+      throw new ReferenceError(`Could not copy over the asset named "${file}"`);
+    }
+
+    ensureDirpath(dest);
+    fs.copyFileSync(file, dest);
+  }
+};
+
+const ensureDirpath = (filepath) => {
+  const parts = filepath.split(path.sep);
+
+  /* istanbul ignore else */
+  if (parts.length > 1) {
+    ensureDirs(parts.slice(0, -1));
+  }
+};
+
 const ensureDirs = (dirs) => {
   let currentDir = '';
 
   for (const dir of dirs) {
     currentDir = path.join(currentDir, dir);
+    ensureDir(currentDir);
+  }
+};
 
-    try {
-      fs.statSync(currentDir);
-    } catch (e) {
-      fs.mkdirSync(currentDir);
-    }
+const ensureDir = (dir) => {
+  try {
+    fs.statSync(dir);
+  } catch (e) {
+    fs.mkdirSync(dir);
   }
 };
 
 const updateMetadata = (original, updates) => {
-  const {
-    content,
-    metadata,
-  } = splitContent(original);
+  const { content, metadata } = splitContent(original);
   const withUpdates = applyMetadataUpdates(metadata, updates);
 
   return withUpdates
@@ -164,7 +180,7 @@ const splitContent = (original) => {
   return {
     content,
     metadata,
-  }
+  };
 };
 
 const applyMetadataUpdates = (metadata, updates) => {
@@ -202,6 +218,7 @@ const applyMetadataUpdates = (metadata, updates) => {
 };
 
 module.exports = {
+  copyFiles,
   deleteFile,
   ensureExt,
   findRoot,

--- a/lib/utils/templates/parse.util.js
+++ b/lib/utils/templates/parse.util.js
@@ -7,6 +7,7 @@ const filesUtil = require('../files.util');
 
 const parse = (prefix, file, templateCache = {}) => {
   const filename = `${prefix}${file}`;
+  let assets = [];
   let cached = templateCache;
   let tree = templateCache[filename];
 
@@ -16,11 +17,13 @@ const parse = (prefix, file, templateCache = {}) => {
 
     parser.parse();
 
+    assets = parser.getAssets();
     cached = parser.getCache();
     tree = parser.getTree();
   }
 
   return {
+    assets,
     cached,
     tree,
   };
@@ -28,6 +31,7 @@ const parse = (prefix, file, templateCache = {}) => {
 
 class Parser {
   constructor(filename, prefix, cache) {
+    this._assets = [];
     this._cache = { ...cache };
     this._filename = filename;
     this._node = null;
@@ -39,9 +43,7 @@ class Parser {
   }
 
   static checkIsChildless(node) {
-    return node
-      && node.content
-      && !node.content.child;
+    return node && node.content && !node.content.child;
   }
 
   static findNextDirective(template) {
@@ -61,6 +63,10 @@ class Parser {
     }
 
     return next;
+  }
+
+  getAssets() {
+    return this._assets;
   }
 
   getCache() {
@@ -87,6 +93,7 @@ class Parser {
 
   _completePreviousNode({ match, directive }, template) {
     const needComplete = [
+      DIRECTIVES.ASSET,
       DIRECTIVES.FOR_LOOP_START,
       DIRECTIVES.IF_BLOCK_START,
       DIRECTIVES.IMPORT_PARTIAL,
@@ -100,6 +107,8 @@ class Parser {
 
   _handleDirective(directive, template) {
     switch (directive.directive) {
+      case DIRECTIVES.ASSET:
+        return this._insertAsset(directive, template);
       case DIRECTIVES.FOR_LOOP_START:
         return this._insertForLoopStart(directive);
       case DIRECTIVES.IF_BLOCK_START:
@@ -108,16 +117,19 @@ class Parser {
       case DIRECTIVES.IF_BLOCK_END:
         return this._insertEndNode(directive, template);
       case DIRECTIVES.IMPORT_PARTIAL:
-        return this._insertPartial(directive, template)
+        return this._insertPartial(directive, template);
     }
   }
 
+  _insertAsset(directive) {
+    const { match } = directive;
+
+    this._assets.push(match[1]);
+    this._insertNode(NODE_TYPES.ASSET, match[1]);
+  }
+
   _insertForLoopStart(directive) {
-    this._insertStartNode(
-      NODE_TYPES.FOR_LOOP,
-      directive.match,
-      'variable',
-    );
+    this._insertStartNode(NODE_TYPES.FOR_LOOP, directive.match, 'variable');
   }
 
   _insertIfBlockStart(directive, template) {
@@ -159,10 +171,7 @@ class Parser {
     /* istanbul ignore else */
     if (!partialTree) {
       // create new parser and parse the partial file
-      const {
-        cache,
-        tree,
-      } = parse(this._prefix, file, this._cache);
+      const { cache, tree } = parse(this._prefix, file, this._cache);
 
       this._cache = {
         ...cache,

--- a/lib/utils/templates/reconstruct.util.js
+++ b/lib/utils/templates/reconstruct.util.js
@@ -12,11 +12,13 @@ const reconstruct = (tree, metadata, contents) => {
     realMeta = {
       ...metadata,
       ...contents,
-    }
+    };
   }
 
   /* istanbul ignore else */
   if (tree.type === NODE_TYPES.TEXT) {
+    ({ content } = tree);
+  } else if (tree.type === NODE_TYPES.ASSET) {
     ({ content } = tree);
   } else if (tree.type === NODE_TYPES.PARTIAL) {
     content += reconstruct(tree.content, realMeta);

--- a/test/utils/dates.util.test.js
+++ b/test/utils/dates.util.test.js
@@ -17,19 +17,19 @@ test('#format should take a date string and format it to the provided format', (
   t.is(dates.format('2018-08-03 08:01:00', 'M/d/yyyy'), '8/3/2018');
 });
 
-test.only('#getCurrent should provide current date & time', (t) => {
+test('#getCurrent should provide current date & time', (t) => {
   t.is(dates.getCurrent(), '2010-03-27 04:30:37');
 });
 
 test('#convertToDate should create a date time from a provided date string', (t) => {
-  const date = new Date('2018-08-13 08:01:00');
+  const date = new Date('2018-08-03 08:01:00');
   const result = dates.convertToDate('2018-08-03 08:01:00');
 
   t.is(result.valueOf(), date.valueOf());
 });
 
 test('#convertToDate should create a date time from a provided date string using a provided format', (t) => {
-  const date = new Date('2018-08-13 08:01:00');
+  const date = new Date('2018-08-03 00:00:00');
   const result = dates.convertToDate('03 Aug 18', 'dd MMM yy');
 
   t.is(result.valueOf(), date.valueOf());

--- a/test/utils/files.util.test.js
+++ b/test/utils/files.util.test.js
@@ -286,6 +286,40 @@ test('#deleteFile should remove the specified filepath', (t) => {
   sandbox.restore();
 });
 
+test('#checkIsDir should return false for an invalid path', (t) => {
+  const sandbox = sinon.createSandbox();
+
+  sandbox.stub(fs, 'statSync').throwsException();
+
+  t.false(files.checkIsDir('not/a/path'));
+
+  sandbox.restore();
+});
+
+test('#checkIsDir should return false for a path which is NOT a directory', (t) => {
+  const sandbox = sinon.createSandbox();
+
+  sandbox.stub(fs, 'statSync').returns({
+    isDirectory: () => false,
+  });
+
+  t.false(files.checkIsDir('non-dir'));
+
+  sandbox.restore();
+});
+
+test('#checkIsDir should return true for a valid directory', (t) => {
+  const sandbox = sinon.createSandbox();
+
+  sandbox.stub(fs, 'statSync').returns({
+    isDirectory: () => true,
+  });
+
+  t.true(files.checkIsDir('is/known/dir'));
+
+  sandbox.restore();
+});
+
 test('#deleteFile should do nothing if the file does not exist', (t) => {
   const sandbox = sinon.createSandbox();
   const exists = sandbox.stub(fs, 'existsSync');


### PR DESCRIPTION
This addresses #4

## Main Changes

To support multimedia, this adds the ability for templates and posts. For any template or post, there is a new Talc directive:

```
talc:asset:<asset-path>
```

This directive tells Talc to grab that static asset and copy it to the `config.built` directory. In a template this would be an HTML comment; in a Markdown post file this would be wrapped in `%`. 

The location of assets can be specified through a new `config.assets` attribute; if not provided, Talc will look for static files at the root of the project.

An example for a template:

```html
<img src="<!-- talc:asset:some-folder/deeper/image.png -->" alt="The alt text" />
```

This would create a `some-folder` directory inside the `config.built` directory and create a `deeper` directory inside `some-folder`. Talc then grabs the file `image.png` from the `some-folder/deeper` directory with respect to `config.assets` and moves it into the `some-folder/deeper` directory inside `config.built`.

The resulting HTML would be:

```html
<img src="some-folder/deeper/image.png" alt="The alt text" />
```

Inside a Markdown post file it's similar but slightly different:

```markdown
![Some alt text](%talc:asset:imgs/mark-me-down.gif)
```

Would create `imgs` in `config.built` and move `imgs/mark-me-down.gif` from `config.assets` into the `imgs` inside `config.built`.

The resulting HTML would be:

```html
<img src="imgs/mark-me-down.gif" alt="Some alt text" />
```

## Supporting Changes

1. `filesUtil.copyFiles` was added to allow files to be copied from one place to another, including directories
2. `filesUtil.checkIsDir` was added to check that a specified path is a directory
3. The `datesUtil` tests weren't all running before; remove the `test.only` in the test file and made sure the tests worked