### PR TITLE
#34 Add special handling for missing update_date value

### DIFF
--- a/lib/operators/convert.js
+++ b/lib/operators/convert.js
@@ -204,39 +204,37 @@ const sortFiles = (files, config) => {
   });
 };
 
-const compareBy = (attribute, a, b, config) => {
+const compareBy = (attribute, metaA, metaB, config) => {
   let compare = compareStrings;
-  let aValue = a[attribute];
-  let bValue = b[attribute];
+  let aValue = metaA[attribute];
+  let bValue = metaB[attribute];
 
   if (
     attribute === 'publish_date' ||
     attribute === 'create_date' ||
     attribute === 'update_date'
   ) {
-    [aValue, bValue] = ensureDateValues(attribute, a, b);
+    [aValue, bValue] = ensureDateValues(attribute, metaA, metaB);
     compare = compareDates;
   }
 
   return compare(aValue, bValue, config);
 };
 
-const ensureDateValues = (attribute, a, b) => {
-  let aValue = a[attribute];
-  let bValue = b[attribute];
+const ensureDateValues = (attribute, metaA, metaB) => {
+  let aValue = metaA[attribute];
+  let bValue = metaB[attribute];
 
   if (attribute === 'update_date') {
-    if (!aValue) {
-      aValue = a.publish_date;
-    }
-
-    if (!bValue) {
-      bValue = b.publish_date;
-    }
+    aValue = ensureUpdateDate(metaA);
+    bValue = ensureUpdateDate(metaB);
   }
 
   return [aValue, bValue];
 };
+
+const ensureUpdateDate = (metadata) =>
+  metadata.update_date || metadata.publish_date;
 
 const compareDates = (a, b, { dateFormat }) => {
   const dateA = datesUtil.convertToDate(a, dateFormat);

--- a/lib/operators/convert.js
+++ b/lib/operators/convert.js
@@ -206,12 +206,36 @@ const sortFiles = (files, config) => {
 
 const compareBy = (attribute, a, b, config) => {
   let compare = compareStrings;
+  let aValue = a[attribute];
+  let bValue = b[attribute];
 
-  if (attribute === 'publish_date' || attribute === 'create_date') {
+  if (
+    attribute === 'publish_date' ||
+    attribute === 'create_date' ||
+    attribute === 'update_date'
+  ) {
+    [aValue, bValue] = ensureDateValues(attribute, a, b);
     compare = compareDates;
   }
 
-  return compare(a[attribute], b[attribute], config);
+  return compare(aValue, bValue, config);
+};
+
+const ensureDateValues = (attribute, a, b) => {
+  let aValue = a[attribute];
+  let bValue = b[attribute];
+
+  if (attribute === 'update_date') {
+    if (!aValue) {
+      aValue = a.publish_date;
+    }
+
+    if (!bValue) {
+      bValue = b.publish_date;
+    }
+  }
+
+  return [aValue, bValue];
 };
 
 const compareDates = (a, b, { dateFormat }) => {


### PR DESCRIPTION
This adds handling, during sorting, that ensures that if a post is being sorted on `update_date` and it does not have one in its metadata, that a value is provided using the `publish_date`.